### PR TITLE
fixed media breakpoint

### DIFF
--- a/stylesheets/scss/application.scss
+++ b/stylesheets/scss/application.scss
@@ -192,7 +192,7 @@ li {
  font-weight: 600;
 }
 
-@media (min-width: 600px) {
+@media (min-width: $tablet) {
   .headline {
     font-size: 33px;
     line-height: 42px;


### PR DESCRIPTION
Breakpoint was set to 600px while $tablet was set to 700px, causing wrong styling to be displayed at displays wider than 600px but less wide than 700px.